### PR TITLE
Grezniczek patch 1

### DIFF
--- a/templates/class.twig
+++ b/templates/class.twig
@@ -10,7 +10,7 @@ class {{ className }} extends \ExternalModules\AbstractExternalModule {
 {% for hook in hooks %}
 	public function {{ hook.name }}{{ hook.args|striptags }}{
 		
-	}{% if (hooks|last!=set or set|last!=hook) %},
+	}{% if (hooks|last!=set or set|last!=hook) %}
 	
 {% endif %}
 {% endfor %}

--- a/templates/newModule.twig
+++ b/templates/newModule.twig
@@ -120,7 +120,7 @@
 							<div class="form-check">
 								<input class="form-check-input" type="checkbox" id="everyPageHooks" name="everyPageHooks">
 							</div>
-							<span class="text-muted">My default, hooks only activate on certain project specific pages. Enable this option to allow system pages to trigger hook calls</span>
+							<span class="text-muted">By default, hooks only activate on certain project specific pages. Enable this option to allow system pages to trigger hook calls</span>
 						</div>
 					</div>
 				</fieldset>


### PR DESCRIPTION
Removed a comma in the class template that leads to invalid PHP code being generated; and fixed a typo.
This fixes issue #2 

Sorry about the changed file endings .. can't seem to find a way around it (editing directly here on GitHub).