### PR TITLE
Several fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /vendor
+/deploy-scripts

--- a/Templater.php
+++ b/Templater.php
@@ -184,10 +184,17 @@ class Templater extends \ExternalModules\AbstractExternalModule {
 			$i++;
 		}
 		
+		$signatureFixes = array (
+			"void" => "",
+			" = NULL," => ",",
+			"int \$" => "\$",
+			"string \$" => "\$"
+		);
+
 		foreach ($hooks as $setName => $set) {
 			foreach ($set as $hookName => $hook) {
 				preg_match('/\(.*\)/', $hook['function'], $matches);
-				$hooks[$setName][$hookName]['args'] = str_replace("void", "", $matches[0]);
+				$hooks[$setName][$hookName]['args'] = str_replace(array_keys($signatureFixes), array_values($signatureFixes), $matches[0]);
 			}
 		}
 		

--- a/Templater.php
+++ b/Templater.php
@@ -139,37 +139,37 @@ class Templater extends \ExternalModules\AbstractExternalModule {
 				"2" => [
 					"name" => "redcap_module_system_disable",
 					"description" => "Triggered when a module gets disabled on Control Center.",
-					"function" => "void <b>redcap_module_system_enable</b> ( <b>\$version</b> )"
+					"function" => "void <b>redcap_module_system_disable</b> ( <b>\$version</b> )"
 				],
 				"3" => [
 					"name" => "redcap_module_system_change_version",
 					"description" => "Triggered when a module version is changed.",
-					"function" => "void <b>redcap_module_system_enable</b> ( <b>\$version</b> )"
+					"function" => "void <b>redcap_module_system_change_version</b> ( <b>\$version, \$old_version</b> )"
 				],
 				"4" => [
 					"name" => "redcap_module_project_enable",
 					"description" => "Triggered when a module gets enabled on a specific project.",
-					"function" => "void <b>redcap_module_system_enable</b> ( <b>\$version</b> )"
+					"function" => "void <b>redcap_module_project_enable</b> ( <b>\$version, \$project_id</b> )"
 				],
 				"5" => [
 					"name" => "redcap_module_project_disable",
 					"description" => "Triggered when a module gets disabled on a specific project.",
-					"function" => "void <b>redcap_module_system_enable</b> ( <b>\$version</b> )"
+					"function" => "void <b>redcap_module_project_disable</b> ( <b>\$version, \$project_id</b> )"
 				],
 				"6" => [
 					"name" => "redcap_module_configure_button_display",
 					"description" => "Triggered when each enabled module defined is rendered. Return <code>null</code> if you don't want to display the Configure button and <code>true</code> to display.",
-					"function" => "void <b>redcap_module_system_enable</b> ( <b>\$version</b> )"
+					"function" => "void <b>redcap_module_configure_button_display</b> ( <b>\$project_id</b> )"
 				],
 				"7" => [
 					"name" => "redcap_module_link_check_display",
 					"description" => "Triggered when each link defined in config.json is rendered. Override this method and return <code>null</code> if you don't want to display the link, or modify and return the <code>\$link</code> parameter as desired. This method also controls whether pages will load if users access their URLs directly.",
-					"function" => "void <b>redcap_module_system_enable</b> ( <b>\$version</b> )"
+					"function" => "void <b>redcap_module_link_check_display</b> ( <b>\$project_id, \$link</b> )"
 				],
 				"8" => [
 					"name" => "redcap_module_save_configuration",
 					"description" => "Triggered after a module configuration is saved.",
-					"function" => "void <b>redcap_module_system_enable</b> ( <b>\$version</b> )"
+					"function" => "void <b>redcap_module_save_configuration</b> ( <b>\$project_id</b> )"
 				]
 			]
 		];
@@ -187,7 +187,7 @@ class Templater extends \ExternalModules\AbstractExternalModule {
 		foreach ($hooks as $setName => $set) {
 			foreach ($set as $hookName => $hook) {
 				preg_match('/\(.*\)/', $hook['function'], $matches);
-				$hooks[$setName][$hookName]['args'] = $matches[0];
+				$hooks[$setName][$hookName]['args'] = str_replace("void", "", $matches[0]);
 			}
 		}
 		

--- a/Templater.php
+++ b/Templater.php
@@ -187,14 +187,16 @@ class Templater extends \ExternalModules\AbstractExternalModule {
 		$signatureFixes = array (
 			"void" => "",
 			" = NULL," => ",",
-			"int \$" => "\$",
-			"string \$" => "\$"
+			"int $" => "$",
+			"string $" => "$"
 		);
 
 		foreach ($hooks as $setName => $set) {
 			foreach ($set as $hookName => $hook) {
 				preg_match('/\(.*\)/', $hook['function'], $matches);
-				$hooks[$setName][$hookName]['args'] = str_replace(array_keys($signatureFixes), array_values($signatureFixes), $matches[0]);
+				$args = strip_tags($matches[0]);
+				$args = str_replace(array_keys($signatureFixes), array_values($signatureFixes), $args);
+				$hooks[$setName][$hookName]['args'] = $args;
 			}
 		}
 		

--- a/Templater.php
+++ b/Templater.php
@@ -185,10 +185,7 @@ class Templater extends \ExternalModules\AbstractExternalModule {
 		}
 		
 		$signatureFixes = array (
-			"void" => "",
-			" = NULL," => ",",
-			"int $" => "$",
-			"string $" => "$"
+			"void" => ""
 		);
 
 		foreach ($hooks as $setName => $set) {

--- a/templates/class.twig
+++ b/templates/class.twig
@@ -10,8 +10,8 @@ class {{ className }} extends \ExternalModules\AbstractExternalModule {
 {% for hook in hooks %}
 	public function {{ hook.name }}{{ hook.args|striptags }}{
 		
-	}{% if (hooks|last!=set or set|last!=hook) %},
+	}
+
 	
-{% endif %}
 {% endfor %}
 }

--- a/templates/class.twig
+++ b/templates/class.twig
@@ -8,7 +8,7 @@ class {{ className }} extends \ExternalModules\AbstractExternalModule {
 	}
 	
 {% for hook in hooks %}
-	public function {{ hook.name }}{{ hook.args|striptags }}{
+	public function {{ hook.name }}{{ hook.args|striptags }} {
 		
 	}
 

--- a/templates/newModule.twig
+++ b/templates/newModule.twig
@@ -120,7 +120,7 @@
 							<div class="form-check">
 								<input class="form-check-input" type="checkbox" id="everyPageHooks" name="everyPageHooks">
 							</div>
-							<span class="text-muted">My default, hooks only activate on certain project specific pages. Enable this option to allow system pages to trigger hook calls</span>
+							<span class="text-muted">By default, hooks only activate on certain project specific pages. Enable this option to allow system pages to trigger hook calls</span>
 						</div>
 					</div>
 				</fieldset>


### PR DESCRIPTION
Fixes EM method signatures (and "void" parameter for REDCap hook methots), issue #5 
Fixes #2  - invalid comma in class template
Fixed a typo ("My default, ..." -> "By default, ...")

(Sorry for the many commits and stuff ... still learning my way around Git)